### PR TITLE
Auto release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ install: "./install-dependencies.sh"
 
 script: "./build.sh"
 
-before_deploy: "./package $TRAVIS_TAG"
+before_deploy: "./package.sh $TRAVIS_TAG"
 
 deploy:
   provider: releases

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Building the Peer-to-Peer Internet
 
+[![Build Status](https://travis-ci.org/tomeshnet/p2p-internet-workshop.svg?branch=master)](https://travis-ci.org/tomeshnet/p2p-internet-workshop)
 [![GitHub release](https://img.shields.io/github/release/tomeshnet/p2p-internet-workshop.svg)](https://github.com/tomeshnet/p2p-internet-workshop/releases)
 
 **Workshop Series** _by Toronto Mesh_, [tomesh.net/peer-to-peer-internet](https://tomesh.net/peer-to-peer-internet/)

--- a/README.md
+++ b/README.md
@@ -57,6 +57,11 @@ Workshop materials such as lesson plans and worksheets are written as simple [Ma
 
 If you want to generate these assets yourself, simply run `./install-dependencies.sh` and `./build.sh` and you will find the generated assets in the `output` folder. The `./package.sh` script is used to zip up the generated assets into archives convenient for download, which is the form you will find in the GitHub Releases.
 
+Travis CI is configured to build, package, and publish a new release to GitHub Releases when you push a new tag, so to publish a new package, all you need is to find the current version with `git tag`, and if the next one should be `v0.4`, you do:
+
+    git tag v0.4
+    git push --tag
+
 When using the GitBook presentations at a workshop, you can either:
 
 - Load the appropriate module from GitHub Pages, such as [module-1-presentation](https://tomeshnet.github.io/p2p-internet-workshop/module-1-presentation/index.html)


### PR DESCRIPTION
These were merged in order to test the build: https://github.com/tomeshnet/p2p-internet-workshop/pull/52 https://github.com/tomeshnet/p2p-internet-workshop/pull/53

This documentation completes the Travis CI release feature.